### PR TITLE
publishing to open-vsx did not work as expected...

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,6 +7,8 @@ on:
       - 'v*'
   pull_request:
     branches: [ master ]
+  # branch or tag created  
+  create:
 
 jobs:
 


### PR DESCRIPTION
The ci-cd workflow "publish" job did not run. The workflow was triggering on "push: tags", and my theory is that when actions-gh-release correctly crated the tag, it was seen as a creation event rather than a push. This commit is meant to test that theory by triggering on create event, to see if the job will trigger when I do a bogus release on my fork.

Note: my fork does not have the secret containing the publish token, so no risk of accidental publishing.