### PR TITLE
Use committer token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,5 +25,13 @@ jobs:
             - uses: pipe-cd/actions-gh-release@v2.6.0
               with:
                 release_file: 'RELEASE'
-                token: ${{ secrets.GITHUB_TOKEN }}
+                # Actions that run using the auto-generated GitHub token are
+                # not allowed to trigger a new workflow run. In this case we want
+                # the tag created by actions-gh-release to trigger the main workflow
+                # and result in publishing the extension to open-vsx.
+                # The following scopes are required when creating the committer token:
+                #  - repo_deployment, public_repo, read:org
+                # See here for more details:
+                # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+                token: ${{ secrets.GH_COMMITTER_TOKEN }}
               

--- a/vscode-trace-extension/src/trace-explorer/trace-tree.ts
+++ b/vscode-trace-extension/src/trace-explorer/trace-tree.ts
@@ -127,7 +127,7 @@ export const zoomHandler = (hasZoomedIn: boolean): void => {
     TraceViewerPanel.zoomOnCurrent(hasZoomedIn);
 };
 
-const openDialog = async (): Promise<vscode.Uri | undefined> => {
+export const openDialog = async (): Promise<vscode.Uri | undefined> => {
     const props: vscode.OpenDialogOptions = {
         title: 'Open Trace',
         canSelectFolders: true,
@@ -144,15 +144,7 @@ const openDialog = async (): Promise<vscode.Uri | undefined> => {
 
 export const fileHandler =
     (analysisTree: AnalysisProvider) =>
-    async (context: vscode.ExtensionContext, traceUri: vscode.Uri | undefined): Promise<void> => {
-        // We need to resolve trace URI before starting the progress dialog because we rely on trace URI for dialog title
-        if (!traceUri) {
-            traceUri = await openDialog();
-            if (!traceUri) {
-                return;
-            }
-        }
-
+    async (context: vscode.ExtensionContext, traceUri: vscode.Uri): Promise<void> => {
         const resolvedTraceURI: vscode.Uri = traceUri;
         vscode.window.withProgress(
             {


### PR DESCRIPTION
Use GitHub token from a committer in gh-release job
    
    It turns-out that using the GitHub token, that's automatically
    generated for each workflow run, does not allow for further
    workflow(s) being triggered. We were relying on that feature,
    for the "publish" job to trigger, after action "actions-gh-release"
    creates a git tag in the repo.